### PR TITLE
DFAST-99: Update parameters to cmd for batch 00 test to include Dutch River v1.ini config

### DIFF
--- a/tests-dist/test_batch.py
+++ b/tests-dist/test_batch.py
@@ -30,7 +30,7 @@ class Test_batch_mode():
         tstdir = "tests/c01 - GendtseWaardNevengeul"
         try:
             os.chdir(tstdir)
-            result = subprocess.run([dfastexe,"--mode","BATCH","--config","config.cfg","--language","NL"], capture_output=True)
+            result = subprocess.run([dfastexe,"--mode","BATCH","--rivers","Dutch_rivers_v1.ini","--config","config.cfg","--language","NL"], capture_output=True)
             outstr = result.stdout.decode('UTF-8').splitlines()
         finally:
             os.chdir(cwd)


### PR DESCRIPTION
- Failing batch file 00 is because it is using wrong river file