### PR TITLE
DFAST-115: use packaging version object and check in GUI for correct version

### DIFF
--- a/dfastmi/batch.py
+++ b/dfastmi/batch.py
@@ -130,8 +130,8 @@ def batch_mode_core(
     ApplicationSettingsHelper.log_text("===", file=report)
 
     cfg_version = config["General"]["Version"]
-    rvr_version = rivers.version
-    if version.parse(cfg_version) != version.parse(rvr_version):
+    
+    if version.parse(cfg_version) != rivers.version:
         raise Exception(
             "Version number of configuration file ({}) must match version number of rivers file ({})".format(
                 cfg_version,
@@ -1980,8 +1980,8 @@ def check_configuration(rivers: RiversObject, config: configparser.ConfigParser)
     """
     try:
         cfg_version = config["General"]["Version"]
-        rvr_version = rivers.version
-        if version.parse(cfg_version) != version.parse(rvr_version):
+        
+        if version.parse(cfg_version) != rivers.version:
             return False
         if version.parse(cfg_version) == version.parse("1.0"):
             return check_configuration_v1(rivers, config)

--- a/dfastmi/gui.py
+++ b/dfastmi/gui.py
@@ -350,6 +350,9 @@ def update_qvalues() -> None:
     ireach = dialog["reach"].currentIndex()
     if ireach < 0:
         return
+    
+    if rivers.version.major < 2 :
+        return
 
     hydro_q = rivers.hydro_q[ibranch][ireach]
     tabs = dialog["tabs"]

--- a/dfastmi/gui.py
+++ b/dfastmi/gui.py
@@ -350,10 +350,7 @@ def update_qvalues() -> None:
     ireach = dialog["reach"].currentIndex()
     if ireach < 0:
         return
-    
-    if rivers.version.major < 2 :
-        return
-
+        
     hydro_q = rivers.hydro_q[ibranch][ireach]
     tabs = dialog["tabs"]
     for j in range(tabs.count()-2,-1,-1):
@@ -651,6 +648,10 @@ def main(rivers_configuration: RiversObject, config: Optional[str] = None) -> No
     global dialog
 
     rivers = rivers_configuration
+    if rivers.version.major < 2 :
+        ApplicationSettingsHelper.log_text("legacy_river_config_loaded")
+        return
+    
     create_dialog()
     dialog["branch"].addItems(rivers.branches)
 

--- a/dfastmi/io/RiversObject.py
+++ b/dfastmi/io/RiversObject.py
@@ -34,8 +34,8 @@ from dfastmi.io.ApplicationSettingsHelper import ApplicationSettingsHelper
 
 from dfastmi.io.RiverParameterData import RiverParameterData
 
-class RiversObject():
-    version: str
+class RiversObject():    
+    version: version # type: ignore
     branches: List[str]
     reaches: List[List[str]]
     allreaches : List[str]
@@ -157,7 +157,7 @@ class RiversObject():
         and their associated default parameter settings.
         """
               
-        self.version = "1.0"
+        self.version = version.parse("1.0")
         self._initialize()        
         self._initialize_legacy() 
 
@@ -187,7 +187,7 @@ class RiversObject():
         filename : str
             The name of the river configuration file (default "rivers.ini").    
         """
-        self.version = "2.0"
+        self.version = version.parse("2.0")
         self._initialize()        
         self._initialize_advanced()
         

--- a/dfastmi/messages.NL.ini
+++ b/dfastmi/messages.NL.ini
@@ -390,3 +390,5 @@ WAARSCHUWING: de directory '{dir}' bestaat al ...=> de directory wordt overschre
 Schatting {nr} voor het sedimentatie volume voor het initi�le jaar wordt bepaald voor sedimentatie gebied {ia}
 [clip_interest]
 Het interessegebied is beperkt tot de het interval {low} tot {high} km
+[legacy_river_config_loaded]
+Het configuratiebestand voor de rivieren is verouderd. Indien u toch van de GUI gebruik wilt maken, gebruik dan een oudere versie.

--- a/dfastmi/messages.UK.ini
+++ b/dfastmi/messages.UK.ini
@@ -383,3 +383,5 @@ WARNING: directory '{dir}' already exists...=> overwriting directory
 computing estimate {nr} of the initial year sedimentation volume for sedimentation area {ia}
 [clip_interest]
 interest area clipped to the range {low} to {high} km
+[legacy_river_config_loaded]
+The configuration for rivieren is legacy. If you still want to use the GUI use an older version of the application.

--- a/tests/io/test_RiversObject.py
+++ b/tests/io/test_RiversObject.py
@@ -65,7 +65,8 @@ class Test_read_rivers2():
         """
         print("current work directory: ", os.getcwd())
         rivers = RiversObject("tests/files/read_rivers_test_2_0_version.ini")
-        assert rivers.version == '2.0'
+        assert rivers.version.major == 2
+        assert rivers.version.minor == 0
     
     def test_read_rivers2_02(self):
         """

--- a/tests/io/test_RiversObject.py
+++ b/tests/io/test_RiversObject.py
@@ -39,7 +39,8 @@ class Test_read_rivers():
         assert rivers.qfit == [[(10.0, 20.0)], [(800.0, 1280.0), (800.0, 1280.0)]]
         assert rivers.qlevels == [[(100.0, 200.0, 300.0, 400.0)], [(1000.0, 2000.0, 3000.0, 4000.0), (1000.0, 2000.0, 3000.0, 4000.0)]]
         assert rivers.dq == [[(5.0, 15.0)], [(1000.0, 1000.0), (1000.0, 1000.0)]]
-        assert rivers.version == '1.0'
+        assert rivers.version.major == 1
+        assert rivers.version.minor == 0
     
     def test_read_rivers_02(self):
         """
@@ -80,7 +81,8 @@ class Test_read_rivers2():
         assert rivers.qstagnant == [[50.0], [0.0, 1500.0]]
         assert rivers.qfit == [[(10.0, 20.0)], [(800.0, 1280.0), (800.0, 1280.0)]]
         
-        assert rivers.version == '2.0'
+        assert rivers.version.major == 2
+        assert rivers.version.minor == 0
         
         assert rivers.autotime == [[False], [False, False]]
         assert rivers.cdisch == [[(11.0, 21.0)], [(11.0, 21.0), (11.0, 21.0)]]


### PR DESCRIPTION
Resolve dfastmi.exe not starting after gui v2 update