### PR TITLE
DFAST-196: Set Qthreshold to a value either with user input or via a config file

### DIFF
--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -681,7 +681,7 @@ class DialogView:
 
             user_inputted_qthreshold = float(self._qthr.text())
 
-            if user_inputted_qthreshold > self._view_model.current_reach.qstagnant  :
+            if user_inputted_qthreshold > self._view_model.current_reach.qstagnant:
                 self._view_model.model.qthreshold = user_inputted_qthreshold
                 self._update_qvalues_table()
                 self._update_condition_files()

--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -678,9 +678,15 @@ class DialogView:
             None
         """
         if self._qthr.hasAcceptableInput():
-            self._view_model.model.qthreshold = float(self._qthr.text())
-            self._update_qvalues_table()
-            self._update_condition_files()
+
+            user_inputted_qthreshold = float(self._qthr.text())
+
+            if user_inputted_qthreshold > self._view_model.current_reach.qstagnant  :
+                self._view_model.model.qthreshold = user_inputted_qthreshold
+                self._update_qvalues_table()
+                self._update_condition_files()
+            else:
+                self._qthr.setText(str(self._view_model.current_reach.qstagnant))
 
     def _update_ucritical(self) -> None:
         """

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -104,8 +104,6 @@ class DialogViewModel(QObject):
             value (AReach): The reach to set.
         """
         self._current_reach = value
-        self.model.qthreshold = 0.0
-        self.model.ucritical = 0.0
         self._initialize_qthreshold()
         self._initialize_ucritical()
         self._update_qvalues()

--- a/tests/gui/test_dialog_view.py
+++ b/tests/gui/test_dialog_view.py
@@ -141,13 +141,15 @@ class Test_dialog_inputs:
         dialog_view._qthr.setText(new_value)
         dialog_view._qthr.editingFinished.emit()
         assert dialog_view._qthr.text() != new_value
-        assert dialog_view._qthr.text() == str(dialog_view._view_model.current_reach.qstagnant)
+        assert dialog_view._qthr.text() == str(
+            dialog_view._view_model.current_reach.qstagnant
+        )
 
         # Test valid input
         new_value = "900.0"
         dialog_view._qthr.setText(new_value)
         dialog_view._qthr.editingFinished.emit()
-        assert dialog_view._qthr.text() == new_value        
+        assert dialog_view._qthr.text() == new_value
 
         # Test invalid input
         invalid_value = "abc"

--- a/tests/gui/test_dialog_view.py
+++ b/tests/gui/test_dialog_view.py
@@ -136,11 +136,18 @@ class Test_dialog_inputs:
         when  : updating the qthreshold QLineEdit
         then  : the qthreshold value should be updated correctly
         """
-        # Test valid input
+        # Test valid input, but less than qstagnant
         new_value = "10.0"
         dialog_view._qthr.setText(new_value)
         dialog_view._qthr.editingFinished.emit()
-        assert dialog_view._qthr.text() == new_value
+        assert dialog_view._qthr.text() != new_value
+        assert dialog_view._qthr.text() == str(dialog_view._view_model.current_reach.qstagnant)
+
+        # Test valid input
+        new_value = "900.0"
+        dialog_view._qthr.setText(new_value)
+        dialog_view._qthr.editingFinished.emit()
+        assert dialog_view._qthr.text() == new_value        
 
         # Test invalid input
         invalid_value = "abc"


### PR DESCRIPTION
If the value is more than the reach qstagnant the Qthreshold will be updated. It will not be lowered if you select a reach with a qstagnant which is lower.

Gui updating only, no tests