### PR TITLE
DFAST-219: UCrit is not correct in GUI after new selection of reach

### DIFF
--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -220,8 +220,10 @@ class DialogView:
         """
         # Update the threshold discharge in the GUI
         self._ucrit.setText(str(ucrit))
-        self._ucrit_label.setText(gui_text("ucrit", placeholder_dictionary={"default":str(default)}))
-    
+        self._ucrit_label.setText(
+            gui_text("ucrit", placeholder_dictionary={"default": str(default)})
+        )
+
     def _update_qthreshold(self, data: float):
         """
         Update the GUI components when the discharge threshold changes.
@@ -232,7 +234,7 @@ class DialogView:
         # Update the threshold discharge in the GUI
         self._qthr.setText(str(data))
 
-        # Update labels and text fields        
+        # Update labels and text fields
         self._update_qvalues_table()
 
     def _update_condition_file_field(
@@ -621,7 +623,15 @@ class DialogView:
         self._ucrit.setToolTip(gui_text("ucrit_tooltip"))
         self._ucrit.editingFinished.connect(self._updated_ucritical)
         self._ucrit.setText(str(self._view_model.ucritical))
-        self._ucrit_label = QLabel(gui_text("ucrit",placeholder_dictionary= {"default":self._view_model.current_reach.ucritical}), self._win)
+        self._ucrit_label = QLabel(
+            gui_text(
+                "ucrit",
+                placeholder_dictionary={
+                    "default": self._view_model.current_reach.ucritical
+                },
+            ),
+            self._win,
+        )
         layout.addRow(self._ucrit_label, self._ucrit)
 
     def _create_qthreshhold_input(

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -153,10 +153,10 @@ class DialogViewModel(QObject):
         self._ucritical = value
         self.model.ucritical = value
         self._ucrit_cache[(self.current_branch, self.current_reach)] = value
-        
+
         # Notify the view of the change
         self.ucritical_changed.emit(self.ucritical, self.current_reach.ucritical)
-    
+
     @property
     def qthreshold(self) -> float:
         """
@@ -340,7 +340,9 @@ class DialogViewModel(QObject):
         """
         self._ucritical = 0.0
         if (self.current_branch, self.current_reach) in self._ucrit_cache:
-            self.ucritical = self._ucrit_cache[(self.current_branch, self.current_reach)]
+            self.ucritical = self._ucrit_cache[
+                (self.current_branch, self.current_reach)
+            ]
         else:
             self.ucritical = self.current_reach.ucritical
 
@@ -449,8 +451,10 @@ class DialogViewModel(QObject):
         self.current_reach = reach
 
         self._initialize_qthreshold()
-        self._ucrit_cache[(self.current_branch, self.current_reach)] = self.model.ucritical
-        self._initialize_ucritical()        
+        self._ucrit_cache[(self.current_branch, self.current_reach)] = (
+            self.model.ucritical
+        )
+        self._initialize_ucritical()
         self._update_slength()
         self._initialize_reference_and_measure()
 

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -30,6 +30,7 @@ import traceback
 
 # ViewModel
 from configparser import ConfigParser
+from typing import Dict, Tuple
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -50,6 +51,7 @@ class DialogViewModel(QObject):
 
     branch_changed = pyqtSignal(str)
     reach_changed = pyqtSignal(str)
+    ucritical_changed = pyqtSignal(float, float)
     qthreshold_changed = pyqtSignal(float)
     slength_changed = pyqtSignal(str)
     make_plot_changed = pyqtSignal(bool)
@@ -61,6 +63,7 @@ class DialogViewModel(QObject):
     measure_files_changed = pyqtSignal(str, float, str)
     _reference_files: FilenameDict = {}
     _measure_files: FilenameDict = {}
+    _ucrit_cache: Dict[Tuple[Branch, AReach], float] = {}
     model: DialogModel
     slength: str = ""
 
@@ -128,6 +131,32 @@ class DialogViewModel(QObject):
         # Notify the view of the change
         self.reach_changed.emit(self.current_reach.name)
 
+    @property
+    def ucritical(self) -> float:
+        """
+        The current critical (minimum) velocity [m/s] for sediment transport.
+        """
+        return self._ucritical
+
+    @ucritical.setter
+    def ucritical(self, value: float):
+        """
+        Setter for the current critical (minimum) velocity [m/s] for sediment transport.
+        After set notify the view of the change.
+
+        Arguments:
+            value (float): The critical (minimum) velocity [m/s] for sediment transport to set.
+        """
+        if self._ucritical == value:
+            return
+
+        self._ucritical = value
+        self.model.ucritical = value
+        self._ucrit_cache[(self.current_branch, self.current_reach)] = value
+        
+        # Notify the view of the change
+        self.ucritical_changed.emit(self.ucritical, self.current_reach.ucritical)
+    
     @property
     def qthreshold(self) -> float:
         """
@@ -309,8 +338,11 @@ class DialogViewModel(QObject):
         """
         Initialize the critical velocity.
         """
-        if self.model.ucritical < self.current_reach.ucritical:
-            self.model.ucritical = self.current_reach.ucritical
+        self._ucritical = 0.0
+        if (self.current_branch, self.current_reach) in self._ucrit_cache:
+            self.ucritical = self._ucrit_cache[(self.current_branch, self.current_reach)]
+        else:
+            self.ucritical = self.current_reach.ucritical
 
     def _initialize_qthreshold(self):
         """
@@ -417,7 +449,8 @@ class DialogViewModel(QObject):
         self.current_reach = reach
 
         self._initialize_qthreshold()
-        self._initialize_ucritical()
+        self._ucrit_cache[(self.current_branch, self.current_reach)] = self.model.ucritical
+        self._initialize_ucritical()        
         self._update_slength()
         self._initialize_reference_and_measure()
 

--- a/dfastmi/io/AReach.py
+++ b/dfastmi/io/AReach.py
@@ -54,6 +54,15 @@ class AReach(IReach):
         super().__init__(_name=reach_name, _config_key_index=reach_config_key_index)
         self._name = reach_name
         self._config_key_index = reach_config_key_index
+    
+    def __hash__(self):
+        return hash((self._name, self._config_key_index))
+    
+    def __eq__(self, other):
+        if not isinstance(other, AReach):
+            return False
+        return (self._name == other._name and
+                self._config_key_index == other._config_key_index)
 
     @property
     def name(self) -> str:

--- a/dfastmi/io/AReach.py
+++ b/dfastmi/io/AReach.py
@@ -54,15 +54,17 @@ class AReach(IReach):
         super().__init__(_name=reach_name, _config_key_index=reach_config_key_index)
         self._name = reach_name
         self._config_key_index = reach_config_key_index
-    
+
     def __hash__(self):
         return hash((self._name, self._config_key_index))
-    
+
     def __eq__(self, other):
         if not isinstance(other, AReach):
             return False
-        return (self._name == other._name and
-                self._config_key_index == other._config_key_index)
+        return (
+            self._name == other._name
+            and self._config_key_index == other._config_key_index
+        )
 
     @property
     def name(self) -> str:

--- a/dfastmi/io/Branch.py
+++ b/dfastmi/io/Branch.py
@@ -60,7 +60,18 @@ class Branch(IBranch, IObserver[AReach]):
         self._name = branch_name
         self._reaches: ObservableList[AReach] = ObservableList[AReach]()
         self._reaches.add_observer(self)
+    
+    def __hash__(self):
+        return hash((self._name, self._qlocation, tuple(self.reaches)))
+    
+    def __eq__(self, other):
+        if not isinstance(other, Branch):
+            return False
+        return (self._name == other._name and
+                self._qlocation == other._qlocation and
+                self._reaches == other._reaches)
 
+    
     def get_reach(self, reach_name: str) -> IReach:
         """
         Return the reach from the read reaches list

--- a/dfastmi/io/Branch.py
+++ b/dfastmi/io/Branch.py
@@ -60,18 +60,19 @@ class Branch(IBranch, IObserver[AReach]):
         self._name = branch_name
         self._reaches: ObservableList[AReach] = ObservableList[AReach]()
         self._reaches.add_observer(self)
-    
+
     def __hash__(self):
         return hash((self._name, self._qlocation, tuple(self.reaches)))
-    
+
     def __eq__(self, other):
         if not isinstance(other, Branch):
             return False
-        return (self._name == other._name and
-                self._qlocation == other._qlocation and
-                self._reaches == other._reaches)
+        return (
+            self._name == other._name
+            and self._qlocation == other._qlocation
+            and self._reaches == other._reaches
+        )
 
-    
     def get_reach(self, reach_name: str) -> IReach:
         """
         Return the reach from the read reaches list

--- a/dfastmi/messages.NL.ini
+++ b/dfastmi/messages.NL.ini
@@ -330,7 +330,7 @@ Referentiebestand (zonder maatregel)
 [gui_measure]
 Bestand met maatregel
 [gui_ucrit]
-Kritische stroomsnelheid [m/s]
+Kritische stroomsnelheid [m/s] (standaard : {default})
 [gui_ucrit_tooltip]
 Minimum stroomsnelheid voor bodemveranderingen
 [gui_length]

--- a/dfastmi/messages.UK.ini
+++ b/dfastmi/messages.UK.ini
@@ -323,7 +323,7 @@ Name of reference file (without measure)
 [gui_measure]
 Name of file with measure
 [gui_ucrit]
-Critical flow velocity [m/s]
+Critical flow velocity [m/s] (default : {default})
 [gui_ucrit_tooltip]
 Minimum flow velocity magnitude at which bed level changes occur ...
 [gui_length]


### PR DESCRIPTION
- set default expected ucrit value in ucrit label for the selected reach and branch
- make caching possible for ucrit during application runtime usage
- take in account ucrit value loaded from app configuration, cache this too