### PR TITLE
DFAST-220: QThreshold is not correct in GUI after new selection of reach

### DIFF
--- a/dfastmi/gui/dialog_model.py
+++ b/dfastmi/gui/dialog_model.py
@@ -116,20 +116,10 @@ class DialogModel:
         """Get Qthreshold."""
         return self.section.getfloat("Qthreshold", 0.0)
 
-    @qthreshold.setter
-    def qthreshold(self, value: float):
-        """Set Qthreshold."""
-        self.section["Qthreshold"] = str(value)
-
     @property
     def ucritical(self) -> float:
         """Get Ucritical."""
         return self.section.getfloat("Ucrit", 0.3)
-
-    @ucritical.setter
-    def ucritical(self, value: float):
-        """Set Ucritical."""
-        self.section["Ucrit"] = str(value)
 
     @property
     def output_dir(self) -> str:
@@ -210,9 +200,32 @@ class DialogModel:
         reach: AReach,
         reference_files: FilenameDict,
         measure_files: FilenameDict,
+        ucritical : float,
+        qthreshold : float
     ) -> bool:
-        """Check configuration."""
-        config = self.get_configuration(branch, reach, reference_files, measure_files)
+        """
+        Check if configuration can be created.
+
+        Arguments
+        ---------
+        branch: Branch
+            Selected branch which is used and should be in this config.
+        reach: AReach
+            Selected reach which is used and should be in this config.
+        reference_files: FilenameDict
+            Selected reference files which is used and should be in this config.
+        measure_files: FilenameDict
+            Selected measure files which is used and should be in this config.
+        ucritical : float
+            Selected minimal critical flow value which is used and should be in this config.
+        qthreshold : float
+            Selected discharge threshold value which is used and should be in this config.
+
+        Returns
+        -------
+            Boolean indicating whether the (D-FAST MI analysis) configuration can be created.
+        """
+        config = self.get_configuration(branch, reach, reference_files, measure_files, ucritical, qthreshold)
         return check_configuration(self.rivers, config)
 
     def get_configuration(
@@ -221,13 +234,26 @@ class DialogModel:
         reach: AReach,
         reference_files: FilenameDict,
         measure_files: FilenameDict,
+        ucritical : float,
+        qthreshold : float
     ) -> ConfigParser:
         """
         Extract a configuration from the GUI.
 
         Arguments
         ---------
-        None
+        branch: Branch
+            Selected branch which is used and should be in this config.
+        reach: AReach
+            Selected reach which is used and should be in this config.
+        reference_files: FilenameDict
+            Selected reference files which is used and should be in this config.
+        measure_files: FilenameDict
+            Selected measure files which is used and should be in this config.
+        ucritical : float
+            Selected minimal critical flow value which is used and should be in this config.
+        qthreshold : float
+            Selected discharge threshold value which is used and should be in this config.
 
         Returns
         -------
@@ -242,8 +268,8 @@ class DialogModel:
             CaseDescription=self.case_description,
             Branch=branch.name,
             Reach=reach.name,
-            Qthreshold=self.qthreshold,
-            Ucrit=self.ucritical,
+            Qthreshold=qthreshold,
+            Ucrit=ucritical,
             OutputDir=self.output_dir,
             Plotting=self.plotting,
             SavePlots=self.save_plots,

--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -91,6 +91,7 @@ class DialogView:
         _reach (QComboBox): The combo box for selecting the river reach.
         _qloc (QLabel): The label for displaying the discharge location.
         _qthr (QLineEdit): The line edit for specifying the discharge threshold.
+        _qthrtxt (Qlabel): The label for specifying the discharge (stagnant) threshold.
         _ucrit (QLineEdit): The line edit for specifying the critical velocity.
         _ucrit_label (QLabel): The label for displaying minimum for specifying the critical velocity.
         _slength (QLabel): The label for displaying the impacted length.
@@ -111,6 +112,7 @@ class DialogView:
     _reach: QComboBox = None
     _qloc: QLabel = None
     _qthr: QLineEdit = None
+    _qthrtxt: QLabel = None
     _ucrit: QLineEdit = None
     _ucrit_label: QLabel = None
     _slength: QLabel = None
@@ -224,17 +226,20 @@ class DialogView:
             gui_text("ucrit", placeholder_dictionary={"default": str(default)})
         )
 
-    def _update_qthreshold(self, data: float):
+    def _update_qthreshold(self, qthreshold: float, qstagnant: float):
         """
         Update the GUI components when the discharge threshold changes.
 
         Args:
-            data: The dischage threshold.
+            qthreshold: The dischage threshold.
+            qstagnant: The dischage stagnant threshold.
         """
         # Update the threshold discharge in the GUI
-        self._qthr.setText(str(data))
+        self._qthr.setText(str(qthreshold))
 
         # Update labels and text fields
+        self._qthrtxt.setText(
+            gui_text("qthr", placeholder_dictionary={"stagnant": str(qstagnant)}))
         self._update_qvalues_table()
 
     def _update_condition_file_field(
@@ -651,9 +656,11 @@ class DialogView:
         self._qthr.setValidator(double_validator)
         self._qthr.editingFinished.connect(self._updated_qthreshold)
         self._qthr.setToolTip(gui_text("qthr_tooltip"))
-        qthrtxt = QLabel(gui_text("qthr"), self._win)
+        
+        qthreshold_label_text = gui_text("qthr", placeholder_dictionary={"stagnant": str(self._view_model.model.qthreshold)})
+        self._qthrtxt = QLabel(qthreshold_label_text, self._win)
         self._qthr.setText(str(self._view_model.model.qthreshold))
-        layout.addRow(qthrtxt, self._qthr)
+        layout.addRow(self._qthrtxt, self._qthr)
 
     def _show_discharge_location(self, layout: QBoxLayout) -> None:
         """

--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -91,7 +91,7 @@ class DialogView:
         _reach (QComboBox): The combo box for selecting the river reach.
         _qloc (QLabel): The label for displaying the discharge location.
         _qthr (QLineEdit): The line edit for specifying the discharge threshold.
-        _qthrtxt (Qlabel): The label for specifying the discharge (stagnant) threshold.
+        _qthr_label (Qlabel): The label for specifying the discharge (stagnant) threshold.
         _ucrit (QLineEdit): The line edit for specifying the critical velocity.
         _ucrit_label (QLabel): The label for displaying minimum for specifying the critical velocity.
         _slength (QLabel): The label for displaying the impacted length.
@@ -112,7 +112,7 @@ class DialogView:
     _reach: QComboBox = None
     _qloc: QLabel = None
     _qthr: QLineEdit = None
-    _qthrtxt: QLabel = None
+    _qthr_label: QLabel = None
     _ucrit: QLineEdit = None
     _ucrit_label: QLabel = None
     _slength: QLabel = None
@@ -187,9 +187,9 @@ class DialogView:
             self._reach.addItem(r.name)
         # Update labels and text fields
         self._qloc.setText(self._view_model.current_branch.qlocation)
-        self._output_dir.setText(self._view_model.model.output_dir)
-        self._make_plots_edit.setChecked(self._view_model.model.plotting)
-        self._save_plots_edit.setChecked(self._view_model.model.save_plots)
+        self._output_dir.setText(self._view_model.output_dir)
+        self._make_plots_edit.setChecked(self._view_model.make_plot)
+        self._save_plots_edit.setChecked(self._view_model.save_plot)
         self._close_plots_edit.setChecked(self._view_model.model.close_plots)
 
     def _update_reach(self, data):
@@ -238,7 +238,7 @@ class DialogView:
         self._qthr.setText(str(qthreshold))
 
         # Update labels and text fields
-        self._qthrtxt.setText(
+        self._qthr_label.setText(
             gui_text("qthr", placeholder_dictionary={"stagnant": str(qstagnant)})
         )
         self._update_qvalues_table()
@@ -477,7 +477,7 @@ class DialogView:
         make_plots = QLabel(gui_text("makePlots"), self._win)
         self._make_plots_edit = QCheckBox(self._win)
         self._make_plots_edit.setToolTip(gui_text("makePlots_tooltip"))
-        self._make_plots_edit.setChecked(self._view_model.model.plotting)
+        self._make_plots_edit.setChecked(self._view_model.make_plot)
         self._make_plots_edit.stateChanged.connect(self._updated_plotting)
         layout.addRow(make_plots, self._make_plots_edit)
 
@@ -660,11 +660,11 @@ class DialogView:
 
         qthreshold_label_text = gui_text(
             "qthr",
-            placeholder_dictionary={"stagnant": str(self._view_model.model.qthreshold)},
+            placeholder_dictionary={"stagnant": str(self._view_model.qthreshold)},
         )
-        self._qthrtxt = QLabel(qthreshold_label_text, self._win)
-        self._qthr.setText(str(self._view_model.model.qthreshold))
-        layout.addRow(self._qthrtxt, self._qthr)
+        self._qthr_label = QLabel(qthreshold_label_text, self._win)
+        self._qthr.setText(str(self._view_model.qthreshold))
+        layout.addRow(self._qthr_label, self._qthr)
 
     def _show_discharge_location(self, layout: QBoxLayout) -> None:
         """
@@ -784,7 +784,7 @@ class DialogView:
         Returns:
             None
         """
-        enabled = self._view_model.model.qthreshold < discharge
+        enabled = self._view_model.qthreshold < discharge
 
         # get the reference file
         q1_reference = self._create_condition_validating_line_edit(

--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -239,7 +239,8 @@ class DialogView:
 
         # Update labels and text fields
         self._qthrtxt.setText(
-            gui_text("qthr", placeholder_dictionary={"stagnant": str(qstagnant)}))
+            gui_text("qthr", placeholder_dictionary={"stagnant": str(qstagnant)})
+        )
         self._update_qvalues_table()
 
     def _update_condition_file_field(
@@ -656,8 +657,11 @@ class DialogView:
         self._qthr.setValidator(double_validator)
         self._qthr.editingFinished.connect(self._updated_qthreshold)
         self._qthr.setToolTip(gui_text("qthr_tooltip"))
-        
-        qthreshold_label_text = gui_text("qthr", placeholder_dictionary={"stagnant": str(self._view_model.model.qthreshold)})
+
+        qthreshold_label_text = gui_text(
+            "qthr",
+            placeholder_dictionary={"stagnant": str(self._view_model.model.qthreshold)},
+        )
         self._qthrtxt = QLabel(qthreshold_label_text, self._win)
         self._qthr.setText(str(self._view_model.model.qthreshold))
         layout.addRow(self._qthrtxt, self._qthr)

--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -54,6 +54,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from dfastmi.io.AReach import AReach
 import dfastmi.kernel.core
 from dfastmi.gui.dialog_model import DialogModel
 from dfastmi.gui.dialog_utils import (
@@ -192,15 +193,26 @@ class DialogView:
         self._save_plots_edit.setChecked(self._view_model.save_plot)
         self._close_plots_edit.setChecked(self._view_model.model.close_plots)
 
-    def _update_reach(self, data):
+    def _update_reach(self, reach : AReach):
         """
         Update the GUI components when the reach changes.
 
         Args:
-            data: The data for the reach.
+            reach: The selected reach.
         """
+
+        # Update the threshold discharge label because of specific selected reach stagnant discharge in the GUI
+        self._qthr_label.setText(
+            gui_text("qthr", placeholder_dictionary={"stagnant": str(reach.qstagnant)})
+        )
+
+        # Update the minimal critical velocity label because of specific selected reach default critical (minimum) velocity in the GUI
+        self._ucrit_label.setText(
+            gui_text("ucrit", placeholder_dictionary={"default": str(reach.ucritical)})
+        )
+        
         # Update reach label
-        self._reach.setCurrentText(data)
+        self._reach.setCurrentText(reach.name)
 
     def _update_sedimentation_length(self, slength: str):
         """
@@ -212,35 +224,27 @@ class DialogView:
         # Update the sedimentation length in the GUI
         self._slength.setText(slength)
 
-    def _update_ucritical(self, ucrit: float, default: float):
+    def _update_ucritical(self, ucrit: float):
         """
         Update the GUI components when the critical (minimum) velocity [m/s] for sediment transport changes.
 
         Args:
-            ucrit: The critical (minimum) velocity [m/s] for sediment transport.
-            default: The default critical (minimum) velocity [m/s] for sediment transport.
+            ucrit: The critical (minimum) velocity [m/s] for sediment transport.            
         """
-        # Update the threshold discharge in the GUI
-        self._ucrit.setText(str(ucrit))
-        self._ucrit_label.setText(
-            gui_text("ucrit", placeholder_dictionary={"default": str(default)})
-        )
+        # Update the critical velocity in the GUI
+        self._ucrit.setText(str(ucrit))        
 
-    def _update_qthreshold(self, qthreshold: float, qstagnant: float):
+    def _update_qthreshold(self, qthreshold: float):
         """
         Update the GUI components when the discharge threshold changes.
 
         Args:
-            qthreshold: The dischage threshold.
-            qstagnant: The dischage stagnant threshold.
+            qthreshold: The dischage threshold.            
         """
         # Update the threshold discharge in the GUI
         self._qthr.setText(str(qthreshold))
 
         # Update labels and text fields
-        self._qthr_label.setText(
-            gui_text("qthr", placeholder_dictionary={"stagnant": str(qstagnant)})
-        )
         self._update_qvalues_table()
 
     def _update_condition_file_field(

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -288,8 +288,9 @@ class DialogViewModel(QObject):
             If thrown, analysis has failed.
         """
         try:
+            run_config = self.model.get_configuration(self.current_branch, self.current_reach, self.reference_files, self.measure_files)
             return dfastmi.batch.core.batch_mode_core(
-                self.model.rivers, False, self.model.config, gui=True
+                self.model.rivers, False, run_config, gui=True
             )
         except:
             stackTrace = traceback.format_exc()
@@ -387,7 +388,7 @@ class DialogViewModel(QObject):
                     self.current_reach.hydro_q,
                     self.current_reach.qfit,
                     self.current_reach.qstagnant,
-                    self.model.qthreshold,
+                    self.qthreshold,
                 )
             else:
                 time_fractions_of_the_year = (
@@ -396,7 +397,7 @@ class DialogViewModel(QObject):
                     )
                 )
                 time_mi = ConfigurationInitializer.calculate_time_mi(
-                    self.model.qthreshold,
+                    self.qthreshold,
                     self.current_reach.hydro_q,
                     time_fractions_of_the_year,
                 )

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -288,7 +288,12 @@ class DialogViewModel(QObject):
             If thrown, analysis has failed.
         """
         try:
-            run_config = self.model.get_configuration(self.current_branch, self.current_reach, self.reference_files, self.measure_files)
+            run_config = self.model.get_configuration(
+                self.current_branch,
+                self.current_reach,
+                self.reference_files,
+                self.measure_files,
+            )
             return dfastmi.batch.core.batch_mode_core(
                 self.model.rivers, False, run_config, gui=True
             )

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -50,9 +50,9 @@ class DialogViewModel(QObject):
     """Represents the ViewModel for the dialog interface."""
 
     branch_changed = pyqtSignal(str)
-    reach_changed = pyqtSignal(str)
-    ucritical_changed = pyqtSignal(float, float)
-    qthreshold_changed = pyqtSignal(float, float)
+    reach_changed = pyqtSignal(AReach)
+    ucritical_changed = pyqtSignal(float)
+    qthreshold_changed = pyqtSignal(float)
     slength_changed = pyqtSignal(str)
     make_plot_changed = pyqtSignal(bool)
     save_plot_changed = pyqtSignal(bool)
@@ -130,7 +130,7 @@ class DialogViewModel(QObject):
         self._initialize_ucritical()
         self._update_slength()
         # Notify the view of the change
-        self.reach_changed.emit(self.current_reach.name)
+        self.reach_changed.emit(self.current_reach)
 
     @property
     def ucritical(self) -> float:
@@ -152,11 +152,10 @@ class DialogViewModel(QObject):
             return
 
         self._ucritical = value
-        self.model.ucritical = value
         self._ucrit_cache[(self.current_branch, self.current_reach)] = value
 
         # Notify the view of the change
-        self.ucritical_changed.emit(self.ucritical, self.current_reach.ucritical)
+        self.ucritical_changed.emit(self.ucritical)
 
     @property
     def qthreshold(self) -> float:
@@ -179,12 +178,11 @@ class DialogViewModel(QObject):
 
         value = max(value, self.current_reach.qstagnant)
         self._qthreshold = value
-        self.model.qthreshold = value
         self._qthreshold_cache[(self.current_branch, self.current_reach)] = value
 
         self._update_slength()
         # Notify the view of the change
-        self.qthreshold_changed.emit(self.qthreshold, self.current_reach.qstagnant)
+        self.qthreshold_changed.emit(self.qthreshold)
 
     @property
     def reference_files(self) -> FilenameDict:
@@ -274,6 +272,8 @@ class DialogViewModel(QObject):
             self.current_reach,
             self.reference_files,
             self.measure_files,
+            self.ucritical,
+            self.qthreshold
         )
 
     def run_analysis(self) -> bool:
@@ -293,6 +293,8 @@ class DialogViewModel(QObject):
                 self.current_reach,
                 self.reference_files,
                 self.measure_files,
+                self.ucritical,
+                self.qthreshold
             )
             return dfastmi.batch.core.batch_mode_core(
                 self.model.rivers, False, run_config, gui=True
@@ -436,6 +438,8 @@ class DialogViewModel(QObject):
             self.current_reach,
             self.reference_files,
             self.measure_files,
+            self.ucritical,
+            self.qthreshold,
         )
         ConfigFileOperations.save_configuration_file(filename, config)
 
@@ -512,4 +516,6 @@ class DialogViewModel(QObject):
             self.current_reach,
             self.reference_files,
             self.measure_files,
+            self.ucritical,
+            self.qthreshold
         )

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -300,11 +300,11 @@ class DialogViewModel(QObject):
                 self.model.rivers, False, run_config, gui=True
             )
         except:
-            stackTrace = traceback.format_exc()
+            stack_trace = traceback.format_exc()
             # Notify the view of the change
             self.analysis_exception.emit(
                 "A run-time exception occurred. Press 'Show Details...' for the full stack trace.",
-                stackTrace,
+                stack_trace,
             )
 
         return False

--- a/dfastmi/gui/dialog_view_model.py
+++ b/dfastmi/gui/dialog_view_model.py
@@ -354,7 +354,10 @@ class DialogViewModel(QObject):
         """
         self._qthreshold = 0.0
         if (self.current_branch, self.current_reach) in self._qthreshold_cache:
-            self.qthreshold = max(self._qthreshold_cache[(self.current_branch, self.current_reach)], self.current_reach.qstagnant)
+            self.qthreshold = max(
+                self._qthreshold_cache[(self.current_branch, self.current_reach)],
+                self.current_reach.qstagnant,
+            )
         else:
             self.qthreshold = self.current_reach.qstagnant
 
@@ -454,10 +457,14 @@ class DialogViewModel(QObject):
             reach = self.current_branch.reaches[0]
         self.current_reach = reach
 
-        self._qthreshold_cache[(self.current_branch, self.current_reach)] = self.model.qthreshold
+        self._qthreshold_cache[(self.current_branch, self.current_reach)] = (
+            self.model.qthreshold
+        )
         self._initialize_qthreshold()
 
-        self._ucrit_cache[(self.current_branch, self.current_reach)] = self.model.ucritical
+        self._ucrit_cache[(self.current_branch, self.current_reach)] = (
+            self.model.ucritical
+        )
         self._initialize_ucritical()
         self._update_slength()
         self._initialize_reference_and_measure()

--- a/dfastmi/messages.NL.ini
+++ b/dfastmi/messages.NL.ini
@@ -320,7 +320,7 @@ Afvoerlocatie
 [gui_qloc_tooltip]
 De locatie waar de afvoerwaardes voor deze tak gedefinieerd zijn ...
 [gui_qthr]
-Minimum afvoer stroomvoerend [m3/s]
+Minimum afvoer stroomvoerend [m3/s] (drempel : {stagnant})
 [gui_qthr_tooltip]
 De maatregel wordt stroomvoerend bij afvoeren [m3/s] vanaf ...
 [gui_qval]

--- a/dfastmi/messages.UK.ini
+++ b/dfastmi/messages.UK.ini
@@ -313,7 +313,7 @@ Discharge location
 [gui_qloc_tooltip]
 The location at which the discharge values for this branch are defined ...
 [gui_qthr]
-Minimum Flow-carrying Discharge [m3/s]
+Minimum Flow-carrying Discharge [m3/s] (stagnant : {stagnant})
 [gui_qthr_tooltip]
 The measure is flow-carrying at for discharges [m3/s] above ...
 [gui_qval]

--- a/tests/gui/test_dialog_model.py
+++ b/tests/gui/test_dialog_model.py
@@ -229,7 +229,7 @@ def test_check_configuration(
 
     # Call the check_configuration method
     result = dialog_model.check_configuration(
-        mock_branch, mock_areach, mock_reference_files, mock_measure_files
+        mock_branch, mock_areach, mock_reference_files, mock_measure_files, 80.1, 8.01
     )
 
     assert (
@@ -238,7 +238,7 @@ def test_check_configuration(
 
     # Assert that get_configuration is called with the correct arguments
     dialog_model.get_configuration.assert_called_once_with(
-        mock_branch, mock_areach, mock_reference_files, mock_measure_files
+        mock_branch, mock_areach, mock_reference_files, mock_measure_files, 80.1, 8.01
     )
 
 
@@ -258,7 +258,7 @@ def test_get_configuration(
     """
     # Call the get_configuration method
     config_parser = dialog_model.get_configuration(
-        mock_branch, mock_areach, mock_reference_files, mock_measure_files
+        mock_branch, mock_areach, mock_reference_files, mock_measure_files, 80.1, 8.01
     )
 
     # Check if the configuration parser is an instance of ConfigParser
@@ -271,8 +271,8 @@ def test_get_configuration(
     general_section = config_parser["General"]
     assert general_section["Branch"] == mock_branch.name
     assert general_section["Reach"] == mock_areach.name
-    assert float(general_section["Qthreshold"]) == dialog_model.qthreshold
-    assert float(general_section["Ucrit"]) == dialog_model.ucritical
+    assert float(general_section["Qthreshold"]) == 8.01
+    assert float(general_section["Ucrit"]) == 80.1
     assert general_section["OutputDir"] == dialog_model.output_dir
     assert general_section.getboolean("Plotting") == dialog_model.plotting
     assert general_section.getboolean("SavePlots") == dialog_model.save_plots
@@ -302,7 +302,7 @@ def test_get_configuration_with_reach(
     """
     # Call the get_configuration method
     config_parser = dialog_model.get_configuration(
-        mock_branch, mock_reach, mock_reference_files, mock_measure_files
+        mock_branch, mock_reach, mock_reference_files, mock_measure_files, 80.1, 8.01
     )
 
     # Check if the configuration parser is an instance of ConfigParser
@@ -315,8 +315,8 @@ def test_get_configuration_with_reach(
     general_section = config_parser["General"]
     assert general_section["Branch"] == mock_branch.name
     assert general_section["Reach"] == mock_reach.name
-    assert float(general_section["Qthreshold"]) == dialog_model.qthreshold
-    assert float(general_section["Ucrit"]) == dialog_model.ucritical
+    assert float(general_section["Qthreshold"]) == 8.01
+    assert float(general_section["Ucrit"]) == 80.1
     assert general_section["OutputDir"] == dialog_model.output_dir
     assert general_section.getboolean("Plotting") == dialog_model.plotting
     assert general_section.getboolean("SavePlots") == dialog_model.save_plots

--- a/tests/gui/test_dialog_view.py
+++ b/tests/gui/test_dialog_view.py
@@ -9,6 +9,7 @@ from dfastmi.gui.dialog_model import DialogModel
 from dfastmi.gui.dialog_utils import gui_text
 from dfastmi.gui.dialog_view import DialogView
 from dfastmi.gui.dialog_view_model import DialogViewModel
+from dfastmi.io.AReach import AReach
 from dfastmi.io.RiversObject import RiversObject
 
 
@@ -160,7 +161,7 @@ class Test_dialog_inputs:
         dialog_view._qthr.setText(invalid_value)
         dialog_view._qthr.editingFinished.emit()
         assert dialog_view._qthr.text() == invalid_value
-        assert dialog_view._view_model.model.qthreshold == float(
+        assert dialog_view._view_model.qthreshold == float(
             new_value
         )  # Input should not change
 
@@ -169,7 +170,7 @@ class Test_dialog_inputs:
         dialog_view._qthr.setText(empty_value)
         dialog_view._qthr.editingFinished.emit()
         assert dialog_view._qthr.text() == empty_value
-        assert dialog_view._view_model.model.qthreshold == float(
+        assert dialog_view._view_model.qthreshold == float(
             new_value
         )  # Input should not change
 
@@ -206,14 +207,14 @@ class Test_dialog_inputs:
         dialog_view._ucrit.setText(invalid_value)
         dialog_view._ucrit.editingFinished.emit()
         assert dialog_view._ucrit.text() == invalid_value
-        assert dialog_view._view_model.model.ucritical == float(new_value)
+        assert dialog_view._view_model.ucritical == float(new_value)
 
         # Test edge case: empty input
         empty_value = ""
         dialog_view._ucrit.setText(empty_value)
         dialog_view._ucrit.editingFinished.emit()
         assert dialog_view._ucrit.text() == empty_value
-        assert dialog_view._view_model.model.ucritical == float(new_value)
+        assert dialog_view._view_model.ucritical == float(new_value)
 
         # Reset to inital value
         dialog_view._ucrit.setText(initial_value)
@@ -487,8 +488,8 @@ class Test_view_model_updates:
         assert (
             dialog_view._qloc.text() == dialog_view._view_model.current_branch.qlocation
         )
-        assert dialog_view._qthr.text() == str(dialog_view._view_model.model.qthreshold)
-        assert dialog_view._ucrit.text() == str(dialog_view._view_model.model.ucritical)
+        assert dialog_view._qthr.text() == str(dialog_view._view_model.qthreshold)
+        assert dialog_view._ucrit.text() == str(dialog_view._view_model.ucritical)
         assert dialog_view._slength.text() == dialog_view._view_model.slength
         assert (
             dialog_view._output_dir.text() == dialog_view._view_model.model.output_dir
@@ -514,7 +515,7 @@ class Test_view_model_updates:
         """
         # Call the method to be tested
         dialog_view._update_reach(
-            "Boven-Waal                   km  868-886"
+            AReach("Boven-Waal                   km  868-886")
         )  # Pass the reach name to simulate the update
 
         # Assertions

--- a/tests/gui/test_dialog_view_model.py
+++ b/tests/gui/test_dialog_view_model.py
@@ -9,8 +9,10 @@ from mock import patch
 from dfastmi.batch.DFastUtils import get_progloc
 from dfastmi.gui.dialog_model import DialogModel
 from dfastmi.gui.dialog_view_model import DialogViewModel
+from dfastmi.io.AReach import AReach
 from dfastmi.io.IBranch import IBranch
 from dfastmi.io.IReach import IReach
+from dfastmi.io.Reach import Reach
 from dfastmi.io.RiversObject import RiversObject
 
 
@@ -164,8 +166,7 @@ def test_updated_reach(qtbot, dialog_view_model):
         result.append(reach)
 
     dialog_view_model.reach_changed.connect(on_reach_changed)
-    mock_reach = mock.create_autospec(spec=IReach)
-    mock_reach.name = "myReach"
+    mock_reach = AReach("myReach")
     mock_reach.qstagnant = 10.0
     mock_reach.ucritical = 5.0
 
@@ -175,8 +176,8 @@ def test_updated_reach(qtbot, dialog_view_model):
         dialog_view_model.current_reach = mock_reach
 
     # Check if the signal was emitted and received correctly
-    assert result == ["myReach"]
-    assert dialog_view_model.current_reach == mock_reach
+    assert result[0] is mock_reach
+    assert dialog_view_model.current_reach is mock_reach
 
 
 def test_get_configuration(dialog_view_model, mock_model):
@@ -210,8 +211,7 @@ def test_load_configuration(dialog_view_model, mock_model):
     mock_branch.name = "myBranch"
     mock_model.rivers.get_branch.return_value = mock_branch
 
-    mock_reach = mock.create_autospec(spec=IReach)
-    mock_reach.name = "myReach"
+    mock_reach = AReach("myReach")
     mock_reach.qstagnant = 10.0
     mock_reach.ucritical = 5.0
     mock_branch.get_reach.return_value = mock_reach


### PR DESCRIPTION
- set min expected qthreshold (reach stagnant discharge) in qthreshold label
- make caching possible for qthreshold during application runtime usage
- take in account qthreshold value loaded from app configuration, cache this too