### PR TITLE
DFAST-226: Resolve criticalsecurity issue when trying to open user manual

### DIFF
--- a/dfastmi/gui/dialog_utils.py
+++ b/dfastmi/gui/dialog_utils.py
@@ -253,7 +253,7 @@ def gui_text(
 
 
 def open_pdf_windows(pdf_path : str):
-    pdf_reader_path = get_default_pdf_reader_windows()
+    pdf_reader_path = _get_default_pdf_reader_windows()
     if pdf_reader_path:
         try:
             # Ensure the path is absolute
@@ -268,7 +268,7 @@ def open_pdf_windows(pdf_path : str):
             print(f"Failed to open the PDF file: {exception}")
 
 
-def get_default_pdf_reader_windows():
+def _get_default_pdf_reader_windows():
     try:
         # Open the registry key for the current user
         with winreg.OpenKey(

--- a/dfastmi/gui/dialog_utils.py
+++ b/dfastmi/gui/dialog_utils.py
@@ -32,8 +32,8 @@ It also includes functions for handling fonts and querying text strings for GUI 
 """
 
 import os
-import winreg
 import subprocess
+import winreg
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -251,35 +251,44 @@ def gui_text(
         application_setting = cstr[0]
     return application_setting
 
-def open_pdf_windows(pdf_path):
-        pdf_reader_path = get_default_pdf_reader_windows()
-        if pdf_reader_path:
-            try:
-                # Ensure the path is absolute
-                pdf_path = os.path.abspath(pdf_path)
 
-                # Open the PDF file with the default PDF reader in a non-blocking way
-                subprocess.Popen([pdf_reader_path, pdf_path], close_fds=True)
-            except Exception as e:
-                print(f"Failed to open the PDF file: {e}")
-    
+def open_pdf_windows(pdf_path):
+    pdf_reader_path = get_default_pdf_reader_windows()
+    if pdf_reader_path:
+        try:
+            # Ensure the path is absolute
+            pdf_path = os.path.abspath(pdf_path)
+
+            # Open the PDF file with the default PDF reader in a non-blocking way
+            subprocess.Popen([pdf_reader_path, pdf_path], close_fds=True)
+        except Exception as e:
+            print(f"Failed to open the PDF file: {e}")
+
+
 def get_default_pdf_reader_windows():
     try:
         # Open the registry key for the current user
-        with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r".pdf", 0, winreg.KEY_READ) as key:
+        with winreg.OpenKey(
+            winreg.HKEY_CLASSES_ROOT, r".pdf", 0, winreg.KEY_READ
+        ) as key:
             # Get the default value of the key
             pdf_association = winreg.QueryValue(key, "")
-        
+
         # Open the registry key for the file association
-        with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, fr"{pdf_association}\shell\open\command", 0, winreg.KEY_READ) as key:
+        with winreg.OpenKey(
+            winreg.HKEY_CLASSES_ROOT,
+            rf"{pdf_association}\shell\open\command",
+            0,
+            winreg.KEY_READ,
+        ) as key:
             # Get the command to open the PDF
             command = winreg.QueryValue(key, "")
-        
+
         # The command might contain additional arguments, extract the path
         if command.startswith('"'):
             path = command.split('"')[1]
         else:
-            path = command.split(' ')[0]
+            path = command.split(" ")[0]
 
         return path
     except Exception as e:

--- a/dfastmi/gui/dialog_utils.py
+++ b/dfastmi/gui/dialog_utils.py
@@ -252,7 +252,7 @@ def gui_text(
     return application_setting
 
 
-def open_pdf_windows(pdf_path):
+def open_pdf_windows(pdf_path : str):
     pdf_reader_path = get_default_pdf_reader_windows()
     if pdf_reader_path:
         try:
@@ -261,8 +261,11 @@ def open_pdf_windows(pdf_path):
 
             # Open the PDF file with the default PDF reader in a non-blocking way
             subprocess.Popen([pdf_reader_path, pdf_path], close_fds=True)
-        except Exception as e:
-            print(f"Failed to open the PDF file: {e}")
+        except (SystemExit, KeyboardInterrupt) as exception:
+            print(f"Failed to open the PDF file: {exception}")
+            raise exception
+        except Exception as exception:
+            print(f"Failed to open the PDF file: {exception}")
 
 
 def get_default_pdf_reader_windows():
@@ -291,6 +294,9 @@ def get_default_pdf_reader_windows():
             path = command.split(" ")[0]
 
         return path
-    except Exception as e:
-        print(f"Failed to get the default PDF reader: {e}")
+    except (SystemExit, KeyboardInterrupt) as exception:
+        print(f"Failed to get the default PDF reader: {exception}")
+        raise exception
+    except Exception as exception:
+        print(f"Failed to get the default PDF reader: {exception}")
         return None

--- a/dfastmi/gui/dialog_view.py
+++ b/dfastmi/gui/dialog_view.py
@@ -26,7 +26,6 @@ Stichting Deltares. All rights reserved.
 INFORMATION
 This file is part of D-FAST Morphological Impact: https://github.com/Deltares/D-FAST_Morphological_Impact
 """
-import os
 import sys
 import traceback
 from functools import partial
@@ -62,6 +61,7 @@ from dfastmi.gui.dialog_utils import (
     ValidatingLineEdit,
     get_available_font,
     gui_text,
+    open_pdf_windows,
 )
 from dfastmi.gui.dialog_view_model import DialogViewModel
 from dfastmi.gui.qt_tools import clear_layout_item
@@ -1006,7 +1006,7 @@ class DialogView:
         ---------
         None
         """
-        os.startfile(self._view_model.manual_filename)
+        open_pdf_windows(self._view_model.manual_filename)
 
     def _open_file_layout(self, my_widget, key: str, enabled: bool):
         """

--- a/tests/gui/test_dialog_view.py
+++ b/tests/gui/test_dialog_view.py
@@ -366,7 +366,8 @@ class Test_popup:
             QMessageBox.setText.assert_called_once_with(
                 "D-FAST Morphological Impact " + dfastmi.__version__
             )
-            QMessageBox.exec_.assert_called_once()    
+            QMessageBox.exec_.assert_called_once()
+
 
 class Test_select:
     def test_selectFolder_output_dir_edit(self, dialog_view: DialogView, monkeypatch):

--- a/tests/gui/test_dialog_view.py
+++ b/tests/gui/test_dialog_view.py
@@ -366,23 +366,7 @@ class Test_popup:
             QMessageBox.setText.assert_called_once_with(
                 "D-FAST Morphological Impact " + dfastmi.__version__
             )
-            QMessageBox.exec_.assert_called_once()
-
-    def test_menu_open_manual(self, dialog_view: DialogView, monkeypatch):
-        """
-        given : dialog_view
-        when  : opening the user manual menu
-        then  : the user manual should be opened correctly
-        """
-        # Mock os.startfile
-        mock_startfile = MagicMock()
-        monkeypatch.setattr("os.startfile", mock_startfile)
-
-        dialog_view._menu_open_manual()
-
-        # Assert that subprocess.Popen was called with the expected arguments
-        mock_startfile.assert_called_once_with(dialog_view._view_model.manual_filename)
-
+            QMessageBox.exec_.assert_called_once()    
 
 class Test_select:
     def test_selectFolder_output_dir_edit(self, dialog_view: DialogView, monkeypatch):


### PR DESCRIPTION
Using default pdf viewer and disable locking of view when pdf is open.

Explanation of File Descriptors
File descriptors are integer handles that represent open files or other I/O resources, such as sockets and pipes. They are used by the operating system to manage these resources. When a new process is spawned, it can inherit file descriptors from the parent process.

Why Use **close_fds**=True
Avoid Blocking: If a file descriptor is tied to a network socket or a pipe, keeping it open in the child process could cause the process to hang or block, especially if the parent process is waiting for data from or sending data to that file descriptor.