### PR TITLE
DFAST-230: Update the header/introduction text

### DIFF
--- a/dfastmi/batch/core.py
+++ b/dfastmi/batch/core.py
@@ -130,9 +130,8 @@ def batch_mode_core(
     )
 
     with report_path.open(mode="w", encoding="utf-8") as report:
-        _log_header(report)
-
         cfg_version = _get_version(rivers, config)
+        _log_header(report, cfg_version)
 
         branch_name = config.get("General", "Branch", fallback="")
         branch = rivers.get_branch(branch_name)
@@ -406,7 +405,7 @@ def _get_version(rivers: RiversObject, config: ConfigParser) -> Version:
     return cfg_version
 
 
-def _log_header(report: TextIO) -> None:
+def _log_header(report: TextIO, cfg_version: Version) -> None:
     """
     Will log into the report default static header information
 
@@ -420,8 +419,12 @@ def _log_header(report: TextIO) -> None:
     None
     """
     prog_version = dfastmi.__version__
+    if cfg_version == Version("1.0"):
+        header = "header_legacy"
+    else:
+        header = "header"
     ApplicationSettingsHelper.log_text(
-        "header", dict={"version": prog_version}, file=report
+        header, dict={"version": prog_version}, file=report
     )
     ApplicationSettingsHelper.log_text("limits", file=report)
     _report_section_break(report)

--- a/dfastmi/cli.py
+++ b/dfastmi/cli.py
@@ -201,7 +201,7 @@ def _interactive_mode_opening(src: TextIO, version: str, report: TextIO) -> bool
         Flag indicating whether the user specified that the simulation results
         are available or not.
     """
-    ApplicationSettingsHelper.log_text("header", dict={"version": version})
+    ApplicationSettingsHelper.log_text("header_legacy", dict={"version": version})
     _interactive_get_bool(src, "confirm")
 
     ApplicationSettingsHelper.log_text("limits")
@@ -226,7 +226,7 @@ def _interactive_mode_opening(src: TextIO, version: str, report: TextIO) -> bool
         ApplicationSettingsHelper.log_text("---")
         tdum = _interactive_get_bool(src, "confirm_or_restart")
 
-    ApplicationSettingsHelper.log_text("header", dict={"version": version}, file=report)
+    ApplicationSettingsHelper.log_text("header_legacy", dict={"version": version}, file=report)
     ApplicationSettingsHelper.log_text("limits", file=report)
     ApplicationSettingsHelper.log_text("===", file=report)
     if have_files:

--- a/dfastmi/messages.NL.ini
+++ b/dfastmi/messages.NL.ini
@@ -4,6 +4,34 @@
 Optie 'reduce_output' is actief.
 
 [header]
+D-FAST Morphological Impact implementeert een algoritme voor het schatten van
+de lokale morfologische effecten door een lokale ingreep. Het conceptueel
+raamwerk is oorspronkelijk geintroduceerd in
+    "RWS-WD memo WAQUA vuistregel 20-10-08"
+maar het is sindsdien uitgebreid en verbeterd. De gebruikershandleiding bevat
+een beschrijving van de huidige versie van het algoritme.
+
+Het is een inschatting van evenwichtsbodemveranderingen in het zomerbed die als
+gevolg van een ingreep en zonder aangepast beheer na lange tijd ontstaan.
+
+Dit betreft het effect op de bodem in [m]:
+
+    jaargemiddeld effect zonder baggeren
+    maximaal effect zonder baggeren
+    minimaal effect zonder baggeren
+
+Met deze bodemveranderingen kunnen knelpunten worden gesignaleerd. De
+resultaten zijn niet direkt geschikt voor het bepalen van de invloed op
+vaargeulonderhoud!
+
+Het totaal volume van de evenwichtsaanzanding en de jaarlijkse sedimentvracht
+door de rivier bepalen tezamen de termijn waarbinnen dit evenwichtseffect kan
+ontwikkelen.
+
+
+Dit is versie {version}.
+
+[header_legacy]
 Dit programma is de "WAQUA vuistregel" voor het schatten
 van lokale morfologische effecten door een lokale ingreep
 (zie RWS-WD memo WAQUA vuistregel 20-10-08).

--- a/dfastmi/messages.UK.ini
+++ b/dfastmi/messages.UK.ini
@@ -6,7 +6,7 @@ The option 'reduce_output' is active.
 [header]
 D-FAST Morphological Impact implements an algorithm to estimate the local
 morphological effects of a local measure (i.e. an adjustment to the river).
-The conceptual framework was orginally introduced in
+The conceptual framework was originally introduced in
     "RWS-WD memo WAQUA vuistregel 20-10-08"
 but it has been extended and improved over the years. Check the user manual
 for the details of the currently implemented algorithm.

--- a/dfastmi/messages.UK.ini
+++ b/dfastmi/messages.UK.ini
@@ -4,6 +4,35 @@
 The option 'reduce_output' is active.
 
 [header]
+D-FAST Morphological Impact implements an algorithm to estimate the local
+morphological effects of a local measure (i.e. an adjustment to the river).
+The conceptual framework was orginally introduced in
+    "RWS-WD memo WAQUA vuistregel 20-10-08"
+but it has been extended and improved over the years. Check the user manual
+for the details of the currently implemented algorithm.
+
+It is based on an estimation of the equilibrium bed level changes in the main
+channel that would occur eventually when river maintenance would not be
+adjusted.
+
+The effect is expressed in [m] as:
+
+    year-averaged bed level change without dredging
+    maximum bed level change without dredging
+    minimum bed level change without dredging
+
+By means of these estimates bottlenecks can be identified. The results are not
+suitable for direct estimation of the impact on the maintenance of the
+navigation channel!
+
+The combination of the total equilibrium sedimentation volume and the yearly
+sediment load of the river determines the period over which the equilibrium
+can be reached.
+
+
+This is version {version}.
+
+[header_legacy]
 This program implements the "WAQUA vuistregel" for the estimation of the local
 morphological effects of a local measure (i.e. an adjustment to the river). See
 "RWS-WD memo WAQUA vuistregel 20-10-08" for details).

--- a/docs/chapters/intro.tex
+++ b/docs/chapters/intro.tex
@@ -53,9 +53,12 @@ It is critical that the flow-carrying capacity of the measure is well represente
 Finally, we reproduce below the introductory section of the text included in every report written by the tool:
 
 \begin{Verbatim}[frame=single, framesep=5pt]
-This program implements the "WAQUA vuistregel" for the estimation of the
-local morphological effects of a local measure (i.e. an adjustment to the
-river). See "RWS-WD memo WAQUA vuistregel 20-10-08" for details).
+D-FAST Morphological Impact implements an algorithm to estimate the local
+morphological effects of a local measure (i.e. an adjustment to the river).
+The conceptual framework was originally introduced in
+    "RWS-WD memo WAQUA vuistregel 20-10-08"
+but it has been extended and improved over the years. Check the user manual
+for the details of the currently implemented algorithm.
 
 It is based on an estimation of the equilibrium bed level changes in the
 main channel that would occur eventually when river maintenance would not
@@ -64,18 +67,16 @@ be adjusted.
 The effect is expressed in [m] as:
 
     year-averaged bed level change without dredging
-    maximum bed level change (after flood season) without dredging
-    minimum bed level change (after low season) without dredging
+    maximum bed level change without dredging
+    minimum bed level change without dredging
 
 By means of these estimates bottlenecks can be identified. The results are
 not suitable for direct estimation of the impact on the maintenance of the
 navigation channel!
 
-The yearly sediment load of the river determines the period in which the
+The combination of the total equilibrium sedimentation volume and the
+yearly sediment load of the river determines the period over which the
 equilibrium can be reached.
 
 This is version ....
-
-The results are not valid for a combination of multiple measures, or for a
-single measure extending over a distance more than 4 km!
 \end{Verbatim}

--- a/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_rkm/report.txt
+++ b/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_rkm/report.txt
@@ -1,6 +1,9 @@
-This program implements the "WAQUA vuistregel" for the estimation of the local
-morphological effects of a local measure (i.e. an adjustment to the river). See
-"RWS-WD memo WAQUA vuistregel 20-10-08" for details).
+D-FAST Morphological Impact implements an algorithm to estimate the local
+morphological effects of a local measure (i.e. an adjustment to the river).
+The conceptual framework was orginally introduced in
+    "RWS-WD memo WAQUA vuistregel 20-10-08"
+but it has been extended and improved over the years. Check the user manual
+for the details of the currently implemented algorithm.
 
 It is based on an estimation of the equilibrium bed level changes in the main
 channel that would occur eventually when river maintenance would not be
@@ -9,15 +12,16 @@ adjusted.
 The effect is expressed in [m] as:
 
     year-averaged bed level change without dredging
-    maximum bed level change (after flood season) without dredging
-    minimum bed level change (after low season) without dredging
+    maximum bed level change without dredging
+    minimum bed level change without dredging
 
 By means of these estimates bottlenecks can be identified. The results are not
 suitable for direct estimation of the impact on the maintenance of the
 navigation channel!
 
-The yearly sediment load of the river determines the period in which the
-equilibrium can be reached.
+The combination of the total equilibrium sedimentation volume and the yearly
+sediment load of the river determines the period over which the equilibrium
+can be reached.
 
 
 This is version 3.0.0.

--- a/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_rkm/report.txt
+++ b/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_rkm/report.txt
@@ -1,6 +1,6 @@
 D-FAST Morphological Impact implements an algorithm to estimate the local
 morphological effects of a local measure (i.e. an adjustment to the river).
-The conceptual framework was orginally introduced in
+The conceptual framework was originally introduced in
     "RWS-WD memo WAQUA vuistregel 20-10-08"
 but it has been extended and improved over the years. Check the user manual
 for the details of the currently implemented algorithm.

--- a/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_special_backward_case/report.txt
+++ b/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_special_backward_case/report.txt
@@ -1,6 +1,9 @@
-This program implements the "WAQUA vuistregel" for the estimation of the local
-morphological effects of a local measure (i.e. an adjustment to the river). See
-"RWS-WD memo WAQUA vuistregel 20-10-08" for details).
+D-FAST Morphological Impact implements an algorithm to estimate the local
+morphological effects of a local measure (i.e. an adjustment to the river).
+The conceptual framework was orginally introduced in
+    "RWS-WD memo WAQUA vuistregel 20-10-08"
+but it has been extended and improved over the years. Check the user manual
+for the details of the currently implemented algorithm.
 
 It is based on an estimation of the equilibrium bed level changes in the main
 channel that would occur eventually when river maintenance would not be
@@ -9,15 +12,16 @@ adjusted.
 The effect is expressed in [m] as:
 
     year-averaged bed level change without dredging
-    maximum bed level change (after flood season) without dredging
-    minimum bed level change (after low season) without dredging
+    maximum bed level change without dredging
+    minimum bed level change without dredging
 
 By means of these estimates bottlenecks can be identified. The results are not
 suitable for direct estimation of the impact on the maintenance of the
 navigation channel!
 
-The yearly sediment load of the river determines the period in which the
-equilibrium can be reached.
+The combination of the total equilibrium sedimentation volume and the yearly
+sediment load of the river determines the period over which the equilibrium
+can be reached.
 
 
 This is version 3.0.0.

--- a/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_special_backward_case/report.txt
+++ b/tests/c01 - GendtseWaardNevengeul/ref_Qmin_Q4000_special_backward_case/report.txt
@@ -1,6 +1,6 @@
 D-FAST Morphological Impact implements an algorithm to estimate the local
 morphological effects of a local measure (i.e. an adjustment to the river).
-The conceptual framework was orginally introduced in
+The conceptual framework was originally introduced in
     "RWS-WD memo WAQUA vuistregel 20-10-08"
 but it has been extended and improved over the years. Check the user manual
 for the details of the currently implemented algorithm.


### PR DESCRIPTION
Update the header/introduction text when D-FAST MI runs using version 2.0/3.0 configuration files (always when using the GUI, and in most cases when running in batch mode).

When using legacy version 1.0 files, the algorithm is equivalent to that of the original WAQMORF code (just with an option to use D-Flow FM results).

Also update the corresponding introduction paragraph in the manuals.