### PR TITLE
mutable default error in dfastmi.batch.AreaDetector

### DIFF
--- a/dfastmi/batch/AreaDetector.py
+++ b/dfastmi/batch/AreaDetector.py
@@ -37,12 +37,12 @@ import numpy
 class AreaData:
     """Class for keeping track of area data."""
 
-    area: numpy.ndarray = numpy.zeros(0)
+    area: numpy.ndarray = field(default_factory=numpy.zeros(0))
     """
     area
     """
 
-    volume: numpy.ndarray = numpy.zeros(0)
+    volume: numpy.ndarray = field(default_factory=numpy.zeros(0))
     """
     area volume
     """
@@ -52,7 +52,7 @@ class AreaData:
     List of sub areas
     """
 
-    total_area_weight: numpy.ndarray = numpy.zeros(0)
+    total_area_weight: numpy.ndarray = field(default_factory=numpy.zeros(0))
     """
     total area weight
     """

--- a/tests-dist/test_basic.py
+++ b/tests-dist/test_basic.py
@@ -58,7 +58,7 @@ class Test_basic:
             "",
             "D-FAST Morphological Impact.",
             "",
-            "optional arguments:",
+            "options:",
             "  -h, --help       show this help message and exit",
             "  --mode MODE      run mode 'BATCH' or 'GUI' (GUI is default)",
             "  --config CONFIG  name of analysis configuration file ('dfastmi.cfg' is",


### PR DESCRIPTION
Addresses "mutable default <class 'numpy.ndarray'> for field area is not allowed: use default_factory" during start-up (occurs in compiled mode)